### PR TITLE
feat(network): add Cloud NAT to allow VPC egress to internet

### DIFF
--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -32,3 +32,17 @@ resource "google_service_networking_connection" "private_vpc_connection" {
   reserved_peering_ranges = [google_compute_global_address.psa_range.name]
 }
 
+resource "google_compute_router" "nat_router" {
+  name    = "${var.network_name}-router"
+  region  = var.region
+  network = google_compute_network.vpc.id
+}
+
+resource "google_compute_router_nat" "nat" {
+  name                               = "${var.network_name}-nat"
+  router                             = google_compute_router.nat_router.name
+  region                             = var.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}
+


### PR DESCRIPTION
Services with all-traffic vpc egress (bff, back_prive) route all outbound traffic through the VPC connector. Without Cloud NAT, calls to external APIs (Twitch, etc.) time out because the VPC has no outbound internet path. The router + NAT gateway fix this.