### PR TITLE
fix(ci): align prod GCP secret name with dev/int convention

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -20,5 +20,5 @@ jobs:
       instance_name: orders-prod
       state_bucket: streamquest-prod-ccm2-terraform-states
     secrets:
-      gcp_credentials: ${{ secrets.GCP_SA_KEY_PROD }}
+      gcp_credentials: ${{ secrets.PROD_GCP_SA_KEY }}
       project_id: ${{ secrets.PROD_GCP_PROJECT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ terraform.rc
 .terraform.lock.hcl
 .terraform
 .idea
+.claude/workspace/


### PR DESCRIPTION
The prod workflow referenced `GCP_SA_KEY_PROD` while dev/int use the `<ENV>_GCP_SA_KEY` pattern. When the GitHub secret is named `PROD_GCP_SA_KEY`, the reference resolved to an empty string and `google-github-actions/auth@v2` failed with: must specify exactly one of workload_identity_provider or credentials_json.

Also ignore .claude/workspace/.